### PR TITLE
Update metadata

### DIFF
--- a/draft-ietf-uta-rfc6125bis.md
+++ b/draft-ietf-uta-rfc6125bis.md
@@ -1,5 +1,5 @@
 ---
-v: 3 
+v: 3
 ipr: trust200902
 docname: draft-ietf-uta-rfc6125bis-latest
 obsoletes: 6125

--- a/draft-ietf-uta-rfc6125bis.md
+++ b/draft-ietf-uta-rfc6125bis.md
@@ -1,10 +1,10 @@
 ---
-stand_alone: true
+v: 3 
 ipr: trust200902
 docname: draft-ietf-uta-rfc6125bis-latest
 obsoletes: 6125
 cat: std
-submissiontype: IETF
+stream: IETF
 pi:
   compact: 'yes'
   subcompact: 'no'


### PR DESCRIPTION
The `v: 3` option is now recommended over `standalone: true`.